### PR TITLE
tile stitching for non-shader terrains, with correct normals

### DIFF
--- a/Runtime/Mapbox/BaseModule/Data/TerrainStrategies/ElevatedTerrainStrategy.cs
+++ b/Runtime/Mapbox/BaseModule/Data/TerrainStrategies/ElevatedTerrainStrategy.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Mapbox.BaseModule.Data.Tiles;
 using Mapbox.BaseModule.Map;
 using Mapbox.BaseModule.Unity;
 using Mapbox.BaseModule.Utilities;
@@ -289,6 +290,112 @@ namespace Mapbox.ImageModule.Terrain.TerrainStrategies
 			//mesh.Triangles.Add(_newTriangleList.ToArray());
 			return mesh;
 		}
+
+
+		/// <summary>
+		/// Checkes all neighbours of the given tile and stitches the edges to achieve a smooth mesh surface.
+		/// </summary>
+		/// <param name="tile">UnityMapTile of the tile being processed.</param>
+		/// <param name="allTiles">All tiles, including this tile, used to find neighbors</param>
+		///
+		public void FixStitches(UnityMapTile tile, Dictionary<UnwrappedTileId, UnityMapTile> allTiles)
+		{
+			UnwrappedTileId tileId = tile.UnwrappedTileId;
+			int sampleCount =  _useTileSkirts 
+				? _elevationOptions.modificationOptions.sampleCount + 3 
+				: _elevationOptions.modificationOptions.sampleCount + 1;
+
+			Vector3[] targetVerts;
+			Vector3[] verts = tile.MeshFilter.sharedMesh.vertices;
+			var meshVertCount = verts.Length;
+			if (allTiles.ContainsKey(tileId.North) && allTiles[tileId.North].TerrainContainer.State == TileContainerState.Final)
+			{
+				targetVerts = allTiles[tileId.North].MeshFilter.sharedMesh.vertices;
+
+				for (int i = 0; i < sampleCount; i++)
+				{
+                    int source_i = meshVertCount - sampleCount + i;
+                    int target_i = i;
+					verts[source_i] = new Vector3(verts[source_i].x, targetVerts[target_i].y, verts[source_i].z);
+				}
+                allTiles[tileId.North].MeshFilter.sharedMesh.vertices = targetVerts;
+			}
+
+			if (allTiles.ContainsKey(tileId.South) && allTiles[tileId.South].TerrainContainer.State == TileContainerState.Final)
+			{
+				targetVerts = allTiles[tileId.South].MeshFilter.sharedMesh.vertices;
+
+				for (int i = 0; i < sampleCount; i++)
+				{
+                    int source_i = i;
+                    int target_i = meshVertCount - sampleCount + i;
+					verts[source_i] = new Vector3(verts[source_i].x, targetVerts[target_i].y, verts[source_i].z);
+				}
+			}
+
+			if (allTiles.ContainsKey(tileId.West) && allTiles[tileId.West].TerrainContainer.State == TileContainerState.Final)
+			{
+				targetVerts = allTiles[tileId.West].MeshFilter.sharedMesh.vertices;
+
+				for (int i = 0; i < sampleCount; i++)
+				{
+                    int target_i = i * sampleCount + sampleCount - 1;
+                    int source_i = i * sampleCount;
+					verts[source_i] = new Vector3(verts[source_i].x, targetVerts[target_i].y, verts[source_i].z);
+				}
+			}
+
+			if (allTiles.ContainsKey(tileId.East) && allTiles[tileId.East].TerrainContainer.State == TileContainerState.Final)
+			{
+				targetVerts = allTiles[tileId.East].MeshFilter.sharedMesh.vertices;
+
+				for (int i = 0; i < sampleCount; i++)
+				{
+                    int target_i = i * sampleCount;
+                    int source_i = i * sampleCount + sampleCount - 1;
+					verts[source_i] = new Vector3(verts[source_i].x, targetVerts[target_i].y, verts[source_i].z);
+				}
+			}
+
+			if (allTiles.ContainsKey(tileId.NorthWest) && allTiles[tileId.NorthWest].TerrainContainer.State == TileContainerState.Final)
+			{
+				targetVerts = allTiles[tileId.NorthWest].MeshFilter.sharedMesh.vertices;
+
+                int source_i = meshVertCount - sampleCount;
+                int target_i = sampleCount - 1;
+                verts[source_i] = new Vector3(verts[source_i].x, targetVerts[target_i].y, verts[source_i].z);
+			}
+
+			if (allTiles.ContainsKey(tileId.NorthEast) && allTiles[tileId.NorthEast].TerrainContainer.State == TileContainerState.Final)
+			{
+				targetVerts = allTiles[tileId.NorthEast].MeshFilter.sharedMesh.vertices;
+
+                int source_i = meshVertCount - 1;
+                int target_i = 0;
+                verts[source_i] = new Vector3(verts[source_i].x, targetVerts[target_i].y, verts[source_i].z);
+			}
+
+			if (allTiles.ContainsKey(tileId.SouthWest) && allTiles[tileId.SouthWest].TerrainContainer.State == TileContainerState.Final)
+			{
+				targetVerts = allTiles[tileId.SouthWest].MeshFilter.sharedMesh.vertices;
+
+                int source_i = 0;
+                int target_i = meshVertCount - 1;
+                verts[source_i] = new Vector3(verts[source_i].x, targetVerts[target_i].y, verts[source_i].z);
+			}
+
+			if (allTiles.ContainsKey(tileId.SouthEast) && allTiles[tileId.SouthEast].TerrainContainer.State == TileContainerState.Final)
+			{
+				targetVerts = allTiles[tileId.SouthEast].MeshFilter.sharedMesh.vertices;
+                int source_i = sampleCount - 1;
+                int target_i = meshVertCount - sampleCount;
+                verts[source_i] = new Vector3(verts[source_i].x, targetVerts[target_i].y, verts[source_i].z);
+			}
+
+			tile.MeshFilter.sharedMesh.vertices = verts;
+			tile.MeshFilter.sharedMesh.RecalculateNormals();
+		}
+
 		#endregion
 	}
 }

--- a/Runtime/Mapbox/BaseModule/Unity/UnityTileTerrainContainer.cs
+++ b/Runtime/Mapbox/BaseModule/Unity/UnityTileTerrainContainer.cs
@@ -48,10 +48,13 @@ namespace Mapbox.BaseModule.Unity
         private void FixMeshBounds(bool useShaderElevation)
         {
             Mesh mesh = _unityMapTile.MeshFilter.mesh;
-            if (mesh != null && useShaderElevation)
+            if (mesh != null)
             {
                 mesh.RecalculateBounds();
-                mesh.bounds = GetBoundsAdjustedForElevation();
+                if (useShaderElevation)
+                {
+                    mesh.bounds = GetBoundsAdjustedForElevation();
+                }
             }
         }
 

--- a/Runtime/Mapbox/ImageModule/Terrain/TerrainLayerModule.cs
+++ b/Runtime/Mapbox/ImageModule/Terrain/TerrainLayerModule.cs
@@ -21,12 +21,12 @@ namespace Mapbox.ImageModule.Terrain
         private TerrainStrategy _terrainStrategy;
         
         //Terrain module doesn't support cpu elevation now after TileCreator changes
-        public TerrainLayerModule(Source<TerrainData> source, TerrainLayerModuleSettings settings) : base()
+        public TerrainLayerModule(Source<TerrainData> source, TerrainLayerModuleSettings settings, TerrainStrategy terrainStrategy) : base()
         {
             _settings = settings;
             _retainedTerrainTiles = new HashSet<CanonicalTileId>();
             _rasterSource = source;
-            _terrainStrategy = new ElevatedTerrainStrategy();
+            _terrainStrategy = terrainStrategy;
         }
         
         public virtual IEnumerator Initialize()

--- a/Runtime/Mapbox/ImageModule/Unity/TerrainLayerModuleScript.cs
+++ b/Runtime/Mapbox/ImageModule/Unity/TerrainLayerModuleScript.cs
@@ -43,7 +43,8 @@ namespace Mapbox.Example.Scripts.ModuleBehaviours
 			var module =
 				new TerrainLayerModule(
 					service.GetTerrainRasterSource(Settings.DataSettings),
-					Settings);
+					Settings,
+					new ElevatedTerrainStrategy());
 
 			mapInformation.QueryElevation = module.QueryElevation;
 			ModuleImplementation = module;


### PR DESCRIPTION
Terrain stitching (called manually, never automatically). Recommended to be called automatically on elevation data loaded, but for now, this works and allows me to call it manually.